### PR TITLE
Interim working changes: streamlined pipeline

### DIFF
--- a/DataProcessing/DataPreProcessing.py
+++ b/DataProcessing/DataPreProcessing.py
@@ -31,6 +31,8 @@ class ModelUniverse(Enum):
 
 class DataPaths(Enum):
     ROOT_DATA_DIR = str(Path.cwd().parent.parent / 'data' / 'SoccerNet' / 'jersey-2023' / 'extracted')
+    TEST_DATA_GT = str(Path(ROOT_DATA_DIR) / 'test' / 'test_gt.json')
+    TRAIN_DATA_GT = str(Path(ROOT_DATA_DIR) / 'train' / 'train_gt.json')
     TEST_DATA_DIR = str(Path(ROOT_DATA_DIR) / 'test' / 'images')
     TRAIN_DATA_DIR = str(Path(ROOT_DATA_DIR) / 'train' / 'images')
     CHALLENGE_DATA_DIR = str(Path(ROOT_DATA_DIR) / 'challenge' / 'images')

--- a/DataProcessing/ImageFeatureTransformPipeline.py
+++ b/DataProcessing/ImageFeatureTransformPipeline.py
@@ -127,7 +127,7 @@ class ImageFeatureTransformPipeline:
         # i.e. this would be the case for just passing 2 images through the pipeline, from the same batch, and appending data for img 2 to img 1.
         output_file = os.path.join(self.output_tracklet_processed_data_path, CommonConstants.FEATURE_DATA_FILE_NAME.value)
         if os.path.exists(output_file):
-            existing = np.load(self.output_tracklet_processed_data_path, allow_pickle=True)
+            existing = np.load(output_file, allow_pickle=True)
             combined = np.concatenate([existing, processed_image], axis=0)
             
             np.save(output_file, combined)

--- a/DataProcessing/ImageFeatureTransformPipeline.py
+++ b/DataProcessing/ImageFeatureTransformPipeline.py
@@ -52,6 +52,11 @@ class ImageFeatureTransformPipeline:
         
     def pass_through_gaussian_outliers_filter(self):
         self.logger.info("Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file")
+        
+        if self.use_cache and os.path.exists(self.current_tracklet_processed_data_dir):
+            self.logger.info(f"Skipping outlier removal for tracklet {self.current_tracklet_number} as cache exists.")
+            return
+        
         command = [
             "python",
             f"{DataPaths.STREAMLINED_PIPELINE.value}\\gaussian_outliers.py",
@@ -96,6 +101,16 @@ class ImageFeatureTransformPipeline:
             np.ndarray: Flattened feature vector(s) with shape (N, d)
         """
         # Update the ver_to_specs dictionary:
+        # Append new features to self.output_tracklet_processed_data_path:
+        # NOTE: The only time we append is when the image tensor batch sent through ImageBatchPipeline is < count(images_in_tracklet).
+        # i.e. this would be the case for just passing 2 images through the pipeline, from the same batch, and appending data for img 2 to img 1.
+        output_file = os.path.join(self.output_tracklet_processed_data_path, CommonConstants.FEATURE_DATA_FILE_NAME.value)
+        
+        # Check if a cache exists
+        if self.use_cache and os.path.exists(output_file):
+            self.logger.info(f"Feature file {output_file} already exists. Skipping processing.")
+            return
+        
         self.ver_to_specs["res50_market"] = (DataPaths.REID_CONFIG_YAML.value, DataPaths.REID_MODEL_1.value)
         self.ver_to_specs["res50_duke"]   = (DataPaths.REID_CONFIG_YAML.value, DataPaths.REID_MODEL_2.value)
         
@@ -122,10 +137,6 @@ class ImageFeatureTransformPipeline:
         # global_feat shape: (N, d). We keep the batch dimension.
         processed_image = global_feat.cpu().numpy()  # shape: (N, d)
         
-        # Append new features to self.output_tracklet_processed_data_path:
-        # NOTE: The only time we append is when the image tensor batch sent through ImageBatchPipeline is < count(images_in_tracklet).
-        # i.e. this would be the case for just passing 2 images through the pipeline, from the same batch, and appending data for img 2 to img 1.
-        output_file = os.path.join(self.output_tracklet_processed_data_path, CommonConstants.FEATURE_DATA_FILE_NAME.value)
         if os.path.exists(output_file):
             existing = np.load(output_file, allow_pickle=True)
             combined = np.concatenate([existing, processed_image], axis=0)
@@ -139,6 +150,11 @@ class ImageFeatureTransformPipeline:
         
     def pass_through_soccer_ball_filter(self):
         self.logger.info("Determine soccer balls in image(s) using pre-trained model.")
+        
+        if self.use_cache and os.path.exists(self.current_tracklet_images_input_dir):
+            self.logger.info(f"Skipping soccer ball filter for tracklet {self.current_tracklet_number} as cache exists.")
+            return
+        
         HEIGHT_MIN = 35
         WIDTH_MIN = 30
 

--- a/ModelDevelopment/ImageBatchPipeline.py
+++ b/ModelDevelopment/ImageBatchPipeline.py
@@ -36,7 +36,6 @@ class ImageBatchPipeline:
                 generate_features: bool,
                 run_filter: bool,
                 run_legible: bool,
-                run_legible_eval: bool,
                 run_pose: bool,
                 run_crops: bool,
                 run_str: bool,
@@ -59,7 +58,6 @@ class ImageBatchPipeline:
         self.generate_features=generate_features
         self.run_filter=run_filter,
         self.run_legible=run_legible,
-        self.run_legible_eval=run_legible_eval,
         self.run_pose=run_pose,
         self.run_crops=run_crops,
         self.run_str=run_str,

--- a/ModelDevelopment/ImageBatchPipeline.py
+++ b/ModelDevelopment/ImageBatchPipeline.py
@@ -133,6 +133,16 @@ class ImageBatchPipeline:
     def pass_through_legibility_classifier(self, use_filtered=True, filter='gauss', exclude_balls=True):
         self.logger.info("Classifying legibility of image(s) using pre-trained model.")
         
+        # if self.use_cache, check if we have a cache
+        if self.use_cache:
+            #legible_results_path, self.legible_tracklets,
+            # if legible_results_path has illegible_results.json and legible_results.json, skip
+            legible_results_path = os.path.join(self.common_processed_data_dir, config.dataset['SoccerNet']['legible_result'])
+            illegible_results_path = os.path.join(self.common_processed_data_dir, config.dataset['SoccerNet']['illegible_result'])
+            if os.path.exists(legible_results_path) and os.path.exists(illegible_results_path):
+                self.logger.info("Using existing cache for legibility classifier. Skipping.")
+                return
+        
         if use_filtered:
             if filter == 'sim': # Do not use
                 path_to_filter_results = os.path.join(self.common_processed_data_dir, config.dataset['SoccerNet']['sim_filtered'])

--- a/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
+++ b/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
@@ -76,32 +76,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:30:34 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
-      "2025-03-12 20:30:34 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
-      "2025-03-12 20:30:34 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
-      "2025-03-12 20:30:34 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
-      "2025-03-12 20:30:34 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
-      "2025-03-12 20:30:34 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
-      "2025-03-12 20:30:34 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
-      "2025-03-12 20:30:34 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-12 20:30:34 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-12 20:30:34 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
-      "2025-03-12 20:30:34 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
-      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
-      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
-      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
-      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
-      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
-      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
-      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
-      "2025-03-12 20:30:34 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
-      "2025-03-12 20:30:34 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-12 20:30:34 [INFO] Min tracklet: 0\n",
-      "2025-03-12 20:30:34 [INFO] Max tracklet: 1426\n",
-      "2025-03-12 20:30:34 [INFO] Using device: cuda\n",
-      "2025-03-12 20:30:34 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-12 20:30:34 [INFO] Min tracklet: 0\n",
-      "2025-03-12 20:30:34 [INFO] Max tracklet: 1426\n"
+      "2025-03-12 21:05:31 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
+      "2025-03-12 21:05:31 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
+      "2025-03-12 21:05:31 [INFO] TEST_DATA_GT: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\test_gt.json\n",
+      "2025-03-12 21:05:31 [INFO] TRAIN_DATA_GT: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\train_gt.json\n",
+      "2025-03-12 21:05:31 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
+      "2025-03-12 21:05:31 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
+      "2025-03-12 21:05:31 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
+      "2025-03-12 21:05:32 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
+      "2025-03-12 21:05:32 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
+      "2025-03-12 21:05:32 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 21:05:32 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 21:05:32 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
+      "2025-03-12 21:05:32 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
+      "2025-03-12 21:05:32 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
+      "2025-03-12 21:05:32 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
+      "2025-03-12 21:05:32 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
+      "2025-03-12 21:05:32 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
+      "2025-03-12 21:05:32 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
+      "2025-03-12 21:05:32 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
+      "2025-03-12 21:05:32 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
+      "2025-03-12 21:05:32 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
+      "2025-03-12 21:05:32 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 21:05:32 [INFO] Min tracklet: 0\n",
+      "2025-03-12 21:05:32 [INFO] Max tracklet: 1426\n",
+      "2025-03-12 21:05:32 [INFO] Using device: cuda\n",
+      "2025-03-12 21:05:32 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 21:05:32 [INFO] Min tracklet: 0\n",
+      "2025-03-12 21:05:32 [INFO] Max tracklet: 1426\n"
      ]
     }
    ],
@@ -110,6 +112,7 @@
     "  input_data_path=DataPaths.TRAIN_DATA_DIR.value,\n",
     "  output_processed_data_path=DataPaths.PROCESSED_DATA_OUTPUT_DIR_TRAIN.value,\n",
     "  common_processed_data_dir=DataPaths.COMMON_PROCESSED_OUTPUT_DATA_TRAIN.value,\n",
+    "  gt_data_path=DataPaths.TRAIN_DATA_GT.value,\n",
     "  single_image_pipeline=False,\n",
     "  display_transformed_image_sample=True,\n",
     "  num_image_samples=1,\n",
@@ -127,14 +130,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:30:34 [INFO] Running the SoccerNet pipeline.\n",
-      "2025-03-12 20:30:34 [INFO] Using single-process GPU mode to generate features.\n"
+      "2025-03-12 21:05:32 [INFO] Running the SoccerNet pipeline.\n",
+      "2025-03-12 21:05:32 [INFO] Using single-process GPU mode to generate features.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ac81cc18cf5d4c809740eb382a3978fc",
+       "model_id": "d9e9aab7bc4f4c6e8b685771d62523fc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -149,27 +152,27 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
-      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
-      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Legibility Classifier.\n"
+      "2025-03-12 21:05:33 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
+      "2025-03-12 21:05:33 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
+      "2025-03-12 21:05:33 [INFO] Creating placeholder data files for Legibility Classifier.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Central Pipeline Progress:   0%|          | 0/1 [00:00<?, ?it/s]"
+      "Phase 1: Data Pre-Processing Pipeline Progress:   0%|          | 0/1 [00:00<?, ?it/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:30:36 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
-      "2025-03-12 20:30:36 [INFO] Skipping soccer ball filter for tracklet 0 as cache exists.\n",
-      "2025-03-12 20:30:36 [INFO] Feature file c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy already exists. Skipping processing.\n",
-      "2025-03-12 20:30:36 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
-      "2025-03-12 20:30:36 [INFO] Skipping outlier removal for tracklet 0 as cache exists.\n"
+      "2025-03-12 21:05:33 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
+      "2025-03-12 21:05:33 [INFO] Skipping soccer ball filter for tracklet 0 as cache exists.\n",
+      "2025-03-12 21:05:33 [INFO] Feature file c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy already exists. Skipping processing.\n",
+      "2025-03-12 21:05:33 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
+      "2025-03-12 21:05:33 [INFO] Skipping outlier removal for tracklet 0 as cache exists.\n"
      ]
     },
     {
@@ -186,16 +189,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:30:36 [INFO] Running model chain on preprocessed image(s).\n",
-      "2025-03-12 20:30:36 [INFO] Classifying legibility of image(s) using pre-trained model.\n",
-      "2025-03-12 20:30:36 [INFO] Using existing cache for legibility classifier. Skipping.\n"
+      "2025-03-12 21:05:33 [INFO] Running model chain on preprocessed image(s).\n",
+      "2025-03-12 21:05:33 [INFO] Classifying legibility of image(s) using pre-trained model.\n",
+      "2025-03-12 21:05:33 [INFO] Using existing cache for legibility classifier. Skipping.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Central Pipeline Progress: 100%|██████████| 1/1 [00:00<00:00,  5.99it/s]\n"
+      "Phase 1: Data Pre-Processing Pipeline Progress: 100%|██████████| 1/1 [00:00<00:00,  5.65it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2025-03-12 21:05:33 [INFO] Evaluating legibility results on 1 tracklets\n",
+      "2025-03-12 21:05:33 [INFO] Correct 1 out of 1. Accuracy 100.0%.\n",
+      "2025-03-12 21:05:33 [INFO] TP=1, TN=0, FP=0, FN=0\n",
+      "2025-03-12 21:05:33 [INFO] Precision=1.0, Recall=1.0\n",
+      "2025-03-12 21:05:33 [INFO] F1=1.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],

--- a/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
+++ b/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -69,39 +69,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:22:28 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
-      "2025-03-12 20:22:28 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
-      "2025-03-12 20:22:28 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
-      "2025-03-12 20:22:28 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
-      "2025-03-12 20:22:28 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
-      "2025-03-12 20:22:28 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
-      "2025-03-12 20:22:28 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
-      "2025-03-12 20:22:28 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-12 20:22:28 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-12 20:22:28 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
-      "2025-03-12 20:22:28 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
-      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
-      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
-      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
-      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
-      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
-      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
-      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
-      "2025-03-12 20:22:28 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
-      "2025-03-12 20:22:28 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-12 20:22:28 [INFO] Min tracklet: 0\n",
-      "2025-03-12 20:22:28 [INFO] Max tracklet: 1426\n",
-      "2025-03-12 20:22:28 [INFO] Using device: cuda\n",
-      "2025-03-12 20:22:28 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-12 20:22:28 [INFO] Min tracklet: 0\n",
-      "2025-03-12 20:22:28 [INFO] Max tracklet: 1426\n"
+      "2025-03-12 20:30:34 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
+      "2025-03-12 20:30:34 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
+      "2025-03-12 20:30:34 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
+      "2025-03-12 20:30:34 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
+      "2025-03-12 20:30:34 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
+      "2025-03-12 20:30:34 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
+      "2025-03-12 20:30:34 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
+      "2025-03-12 20:30:34 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 20:30:34 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 20:30:34 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
+      "2025-03-12 20:30:34 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
+      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
+      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
+      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
+      "2025-03-12 20:30:34 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
+      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
+      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
+      "2025-03-12 20:30:34 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
+      "2025-03-12 20:30:34 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
+      "2025-03-12 20:30:34 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 20:30:34 [INFO] Min tracklet: 0\n",
+      "2025-03-12 20:30:34 [INFO] Max tracklet: 1426\n",
+      "2025-03-12 20:30:34 [INFO] Using device: cuda\n",
+      "2025-03-12 20:30:34 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 20:30:34 [INFO] Min tracklet: 0\n",
+      "2025-03-12 20:30:34 [INFO] Max tracklet: 1426\n"
      ]
     }
    ],
@@ -120,21 +120,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:22:28 [INFO] Running the SoccerNet pipeline.\n",
-      "2025-03-12 20:22:28 [INFO] Using single-process GPU mode to generate features.\n"
+      "2025-03-12 20:30:34 [INFO] Running the SoccerNet pipeline.\n",
+      "2025-03-12 20:30:34 [INFO] Using single-process GPU mode to generate features.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b27e6da31d134f7ebcdd114a68fb64ce",
+       "model_id": "ac81cc18cf5d4c809740eb382a3978fc",
        "version_major": 2,
        "version_minor": 0
       },
@@ -149,9 +149,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
-      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
-      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Legibility Classifier.\n"
+      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
+      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
+      "2025-03-12 20:30:36 [INFO] Creating placeholder data files for Legibility Classifier.\n"
      ]
     },
     {
@@ -165,27 +165,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:22:29 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
-      "2025-03-12 20:22:29 [INFO] Found 0 balls, Ball list: []\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Lightning automatically upgraded your loaded checkpoint from v1.1.4 to v2.5.0.post0. To apply the upgrade to your files permanently, run `python -m pytorch_lightning.utilities.upgrade_checkpoint c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt`\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "using GPU\n",
-      "2025-03-12 20:22:30 [INFO] Saved features for tracklet with shape (1, 2048) to c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy\n",
-      "2025-03-12 20:22:30 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
-      "2025-03-12 20:22:34 [INFO] \n",
-      "2025-03-12 20:22:34 [ERROR] \n",
-      "2025-03-12 20:22:34 [INFO] Done removing outliers\n"
+      "2025-03-12 20:30:36 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
+      "2025-03-12 20:30:36 [INFO] Skipping soccer ball filter for tracklet 0 as cache exists.\n",
+      "2025-03-12 20:30:36 [INFO] Feature file c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy already exists. Skipping processing.\n",
+      "2025-03-12 20:30:36 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
+      "2025-03-12 20:30:36 [INFO] Skipping outlier removal for tracklet 0 as cache exists.\n"
      ]
     },
     {
@@ -202,20 +186,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-12 20:22:34 [INFO] Running model chain on preprocessed image(s).\n",
-      "2025-03-12 20:22:34 [INFO] Classifying legibility of image(s) using pre-trained model.\n",
-      "2025-03-12 20:22:42 [INFO] Saving legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
-      "2025-03-12 20:22:42 [INFO] Saved legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
-      "2025-03-12 20:22:42 [INFO] Saving illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
-      "2025-03-12 20:22:42 [INFO] Saved illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
-      "2025-03-12 20:22:42 [INFO] Legibility classification complete.\n"
+      "2025-03-12 20:30:36 [INFO] Running model chain on preprocessed image(s).\n",
+      "2025-03-12 20:30:36 [INFO] Classifying legibility of image(s) using pre-trained model.\n",
+      "2025-03-12 20:30:36 [INFO] Using existing cache for legibility classifier. Skipping.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Central Pipeline Progress: 100%|██████████| 1/1 [00:12<00:00, 12.86s/it]\n"
+      "Central Pipeline Progress: 100%|██████████| 1/1 [00:00<00:00,  5.99it/s]\n"
      ]
     }
    ],

--- a/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
+++ b/ModelDevelopment/experiments/colin_pipeline_streamlining.ipynb
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -69,39 +69,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-09 21:23:38 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
-      "2025-03-09 21:23:38 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
-      "2025-03-09 21:23:38 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
-      "2025-03-09 21:23:38 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
-      "2025-03-09 21:23:38 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
-      "2025-03-09 21:23:38 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
-      "2025-03-09 21:23:38 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
-      "2025-03-09 21:23:38 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-09 21:23:38 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
-      "2025-03-09 21:23:38 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
-      "2025-03-09 21:23:38 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
-      "2025-03-09 21:23:38 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
-      "2025-03-09 21:23:38 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
-      "2025-03-09 21:23:38 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
-      "2025-03-09 21:23:38 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
-      "2025-03-09 21:23:38 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
-      "2025-03-09 21:23:38 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
-      "2025-03-09 21:23:38 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
-      "2025-03-09 21:23:38 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
-      "2025-03-09 21:23:38 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-09 21:23:38 [INFO] Min tracklet: 0\n",
-      "2025-03-09 21:23:38 [INFO] Max tracklet: 1426\n",
-      "2025-03-09 21:23:38 [INFO] Using device: cuda\n",
-      "2025-03-09 21:23:38 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
-      "2025-03-09 21:23:38 [INFO] Min tracklet: 0\n",
-      "2025-03-09 21:23:38 [INFO] Max tracklet: 1426\n"
+      "2025-03-12 20:22:28 [INFO] DataPreProcessing initialized. Universe of available data paths:\n",
+      "2025-03-12 20:22:28 [INFO] ROOT_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\n",
+      "2025-03-12 20:22:28 [INFO] TEST_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\test\\images\n",
+      "2025-03-12 20:22:28 [INFO] TRAIN_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\train\\images\n",
+      "2025-03-12 20:22:28 [INFO] CHALLENGE_DATA_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\extracted\\challenge\\images\n",
+      "2025-03-12 20:22:28 [INFO] PRE_TRAINED_MODELS_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\n",
+      "2025-03-12 20:22:28 [INFO] REID_PRE_TRAINED: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\n",
+      "2025-03-12 20:22:28 [INFO] REID_MODEL_1: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 20:22:28 [INFO] REID_MODEL_2: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\market1501_resnet50_256_128_epoch_120.ckpt\n",
+      "2025-03-12 20:22:28 [INFO] REID_CONFIG_YAML: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\configs\\256_resnet50.yml\n",
+      "2025-03-12 20:22:28 [INFO] RESNET_MODEL: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\resnet\\legibility_resnet34_soccer_20240215.pth\n",
+      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\n",
+      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\n",
+      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\n",
+      "2025-03-12 20:22:28 [INFO] PROCESSED_DATA_OUTPUT_DIR_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\n",
+      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TRAIN: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\n",
+      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_TEST: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\test\\common_data\n",
+      "2025-03-12 20:22:28 [INFO] COMMON_PROCESSED_OUTPUT_DATA_CHALLENGE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\challenge\\common_data\n",
+      "2025-03-12 20:22:28 [INFO] STREAMLINED_PIPELINE: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\StreamlinedPipelineScripts\n",
+      "2025-03-12 20:22:28 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 20:22:28 [INFO] Min tracklet: 0\n",
+      "2025-03-12 20:22:28 [INFO] Max tracklet: 1426\n",
+      "2025-03-12 20:22:28 [INFO] Using device: cuda\n",
+      "2025-03-12 20:22:28 [INFO] ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']\n",
+      "2025-03-12 20:22:28 [INFO] Min tracklet: 0\n",
+      "2025-03-12 20:22:28 [INFO] Max tracklet: 1426\n"
      ]
     }
    ],
@@ -113,28 +113,28 @@
     "  single_image_pipeline=False,\n",
     "  display_transformed_image_sample=True,\n",
     "  num_image_samples=1,\n",
-    "  use_cache=False,\n",
+    "  use_cache=True,\n",
     "  suppress_logging=False\n",
     "  )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-09 21:23:38 [INFO] Running the SoccerNet pipeline.\n",
-      "2025-03-09 21:23:38 [INFO] Using single-process GPU mode to generate features.\n"
+      "2025-03-12 20:22:28 [INFO] Running the SoccerNet pipeline.\n",
+      "2025-03-12 20:22:28 [INFO] Using single-process GPU mode to generate features.\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "da7721e2c96f4faa9dad5b456c9a7400",
+       "model_id": "b27e6da31d134f7ebcdd114a68fb64ce",
        "version_major": 2,
        "version_minor": 0
       },
@@ -149,9 +149,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-09 21:23:40 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
-      "2025-03-09 21:23:40 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
-      "2025-03-09 21:23:40 [INFO] Creating placeholder data files for Legibility Classifier.\n"
+      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Soccer Ball Filter.\n",
+      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Gaussian Outliers.\n",
+      "2025-03-12 20:22:29 [INFO] Creating placeholder data files for Legibility Classifier.\n"
      ]
     },
     {
@@ -165,16 +165,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-09 21:23:40 [INFO] Removed cached tracklet feature file (use_cache: False): c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy\n",
-      "2025-03-09 21:23:40 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
-      "2025-03-09 21:23:40 [INFO] Found 0 balls, Ball list: []\n"
+      "2025-03-12 20:22:29 [INFO] Determine soccer balls in image(s) using pre-trained model.\n",
+      "2025-03-12 20:22:29 [INFO] Found 0 balls, Ball list: []\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\colin\\miniconda3\\envs\\UBC\\Lib\\site-packages\\pytorch_lightning\\utilities\\migration\\migration.py:208: You have multiple `ModelCheckpoint` callback states in this checkpoint, but we found state keys that would end up colliding with each other after an upgrade, which means we can't differentiate which of your checkpoint callbacks needs which states. At least one of your `ModelCheckpoint` callbacks will not be able to reload the state.\n",
       "Lightning automatically upgraded your loaded checkpoint from v1.1.4 to v2.5.0.post0. To apply the upgrade to your files permanently, run `python -m pytorch_lightning.utilities.upgrade_checkpoint c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\pre_trained_models\\reid\\dukemtmcreid_resnet50_256_128_epoch_120.ckpt`\n"
      ]
     },
@@ -183,11 +181,11 @@
      "output_type": "stream",
      "text": [
       "using GPU\n",
-      "2025-03-09 21:23:42 [INFO] Saved features for tracklet with shape (1, 2048) to c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy\n",
-      "2025-03-09 21:23:42 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
-      "2025-03-09 21:23:47 [INFO] \n",
-      "2025-03-09 21:23:47 [ERROR] \n",
-      "2025-03-09 21:23:47 [INFO] Done removing outliers\n"
+      "2025-03-12 20:22:30 [INFO] Saved features for tracklet with shape (1, 2048) to c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\0\\features.npy\n",
+      "2025-03-12 20:22:30 [INFO] Identifying and removing outliers by calling gaussian_outliers_streamlined.py on feature file\n",
+      "2025-03-12 20:22:34 [INFO] \n",
+      "2025-03-12 20:22:34 [ERROR] \n",
+      "2025-03-12 20:22:34 [INFO] Done removing outliers\n"
      ]
     },
     {
@@ -204,36 +202,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2025-03-09 21:23:47 [INFO] Running model chain on preprocessed image(s).\n",
-      "2025-03-09 21:23:47 [INFO] Classifying legibility of image(s) using pre-trained model.\n"
+      "2025-03-12 20:22:34 [INFO] Running model chain on preprocessed image(s).\n",
+      "2025-03-12 20:22:34 [INFO] Classifying legibility of image(s) using pre-trained model.\n",
+      "2025-03-12 20:22:42 [INFO] Saving legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
+      "2025-03-12 20:22:42 [INFO] Saved legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
+      "2025-03-12 20:22:42 [INFO] Saving illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
+      "2025-03-12 20:22:42 [INFO] Saved illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
+      "2025-03-12 20:22:42 [INFO] Legibility classification complete.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\colin\\miniconda3\\envs\\UBC\\Lib\\site-packages\\torchvision\\models\\_utils.py:208: UserWarning: The parameter 'pretrained' is deprecated since 0.13 and may be removed in the future, please use 'weights' instead.\n",
-      "  warnings.warn(\n",
-      "c:\\Users\\colin\\miniconda3\\envs\\UBC\\Lib\\site-packages\\torchvision\\models\\_utils.py:223: UserWarning: Arguments other than a weight enum or `None` for 'weights' are deprecated since 0.13 and may be removed in the future. The current behavior is equivalent to passing `weights=ResNet34_Weights.IMAGENET1K_V1`. You can also use `weights=ResNet34_Weights.DEFAULT` to get the most up-to-date weights.\n",
-      "  warnings.warn(msg)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2025-03-09 21:23:54 [INFO] Saving legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
-      "2025-03-09 21:23:54 [INFO] Saved legible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\legible_results.json\n",
-      "2025-03-09 21:23:54 [INFO] Saving illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
-      "2025-03-09 21:23:54 [INFO] Saved illegible_tracklets to: c:\\Users\\colin\\OneDrive\\Desktop\\UBC\\Jersey-Number-Recognition\\data\\SoccerNet\\jersey-2023\\processed_data\\train\\common_data\\illegible_results.json\n",
-      "2025-03-09 21:23:54 [INFO] Legibility classification complete.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Central Pipeline Progress: 100%|██████████| 1/1 [00:13<00:00, 13.36s/it]\n"
+      "Central Pipeline Progress: 100%|██████████| 1/1 [00:12<00:00, 12.86s/it]\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary of Changes
- `fixed` problematic caching by adding a `use_cache` check at every pipeline layer. If you specify `True`, it works properly now and uses the existing cached data, not redoing operations.
- `integrated` the legibility evaluation layer

### Thoughts on steps moving forward
One of the main points of the streamlined pipeline was to have complete control over the pre-processing steps before major models are used for actual number recognition. The reason for this is that defining the retrieval model for MoE will rely on heavy data augmentation, and a lot of experiments are going to be done here, and Interpretability is necessary. This component is now fulfilled, and the next step is integrating the actual number recognition models, which is going to be heavy. 

Since I have noticed that legibility results are a hard pre-req before passing data through the models, it might be best to decouple the CentralPipeline  into a preliminary Data Preprocessing step (which is every layer added thus far), and then a digit recognition step that simply moves over the calls to the models in `main.py` to my `CentralPipeline` script. In practice, this just means not using that global tracklet iterator any more for the sake of time-saving, but I will need to make those model scripts accept a tracklets_to_run param so we run on the subset of data specified so we can work on small portions of data when testing things out for accelerated results.